### PR TITLE
fix shortcode for hosted site

### DIFF
--- a/layouts/shortcodes/protobuf.html
+++ b/layouts/shortcodes/protobuf.html
@@ -1,4 +1,4 @@
 {{ $protoName := .Get "name" }}
 {{ $protoDocsSummary := index .Site.Data.ProtoMap.apis $protoName }}
 {{ $protoDocsUrl := lower $protoDocsSummary.relativepath }}
-<a {{ printf "href=/%v%v" .Site.Data.Solo.DocsVersion $protoDocsUrl | safeHTMLAttr }}>{{ $protoName }}</a>
+<a {{ printf "href=%v/%v" .Site.Data.Solo.DocsVersion $protoDocsUrl | safeHTMLAttr }}>{{ $protoName }}</a>


### PR DESCRIPTION
related to https://github.com/solo-io/gloo/issues/1413

fixes concatenation issue, now producing `/gloo/latest/api/etc` instead of `/gloo/latestapi/etc`