### PR TITLE
Mobile, menu fixes.  Auto-gen for version menu research

### DIFF
--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -17,7 +17,7 @@
         >
           {{ .Site.Data.Solo.CodeVersion }}
         </div>-->
-        <label for="version-selection">Version:</label>
+        <!--<label for="version-selection">Version:</label>
         <select id="version-selection" onchange="javascript:location.href = this.value;">
           <option value="/latest/{{ .RelPermalink}}" {{if in .RelPermalink "latest/"}} selected{{end}}>
             latest
@@ -40,17 +40,8 @@
           <option value="/0.20.13/{{ .RelPermalink}}" {{if in .RelPermalink "0.20.13/"}} selected{{end}}>
             0.20.13
           </option>
-        </select>
-        <!--
-        <select>
-          
-    <option>
-      <a href="latest/{{ .RelPermalink}}">latest</a>
-    </option>
-    <option>
-      <a href="1.2.0/{{ .RelPermalink}}">1.2.0</a>
-    </option>
         </select>-->
+        {{ partial "versionnavigation.html" . }}
 
         {{- with .Site.Menus.shortcuts}}
           {{- range sort . "Weight"}}
@@ -65,6 +56,7 @@
   </div>
 </header>
 <article>
+  <div class="leftMenuBuffer"></div>
   <aside>
     <ul class="menu">
       <a id="topic-logo" href="{{ .Site.BaseURL }}{{ .Site.Data.Solo.DocsVersion }}">

--- a/layouts/partials/versionnavigation.html
+++ b/layouts/partials/versionnavigation.html
@@ -9,7 +9,7 @@
 <!-- Need to run throuugh a RANGE of .Site.Data.Solo.DocsVersions .  This is tough to test locally as the version folders aren't generated -->
 <label for="version-selection" id="version-selection-label">Version:</label>
 <select id="version-selection" onchange="javascript:location.href = this.value;">
-  <option value="/latest{{ .RelPermalink}}" {{if in .RelPermalink "latest/"}} selected{{end}}>
+  <option value="/gloo/latest{{ .RelPermalink}}" {{if in .RelPermalink "latest/"}} selected{{end}}>
     latest
   </option>
   <option value="/gloo/1.3.0{{ .RelPermalink}}" {{if in .RelPermalink "1.3.0/"}} selected{{end}}>

--- a/layouts/partials/versionnavigation.html
+++ b/layouts/partials/versionnavigation.html
@@ -9,7 +9,7 @@
 <!-- Need to run throuugh a RANGE of .Site.Data.Solo.DocsVersions .  This is tough to test locally as the version folders aren't generated -->
 <label for="version-selection" id="version-selection-label">Version:</label>
 <select id="version-selection" onchange="javascript:location.href = this.value;">
-  <option value="/latest/{{ .RelPermalink}}" {{if in .RelPermalink "latest/"}} selected{{end}}>
+  <option value="/latest{{ .RelPermalink}}" {{if in .RelPermalink "latest/"}} selected{{end}}>
     latest
   </option>
   <option value="/gloo/1.3.0{{ .RelPermalink}}" {{if in .RelPermalink "1.3.0/"}} selected{{end}}>

--- a/layouts/partials/versionnavigation.html
+++ b/layouts/partials/versionnavigation.html
@@ -1,5 +1,5 @@
-<!-- templates -->
-{{- define "version-nav" }}
+<label for="version-selection" id="version-selection-label">Version:</label>
+<select id="version-selection" onchange="javascript:location.href = this.value;">
   <option value="/latest/{{ .RelPermalink}}" {{if in .RelPermalink "latest/"}} selected{{end}}>
     latest
   </option>
@@ -21,4 +21,4 @@
   <option value="/0.20.13/{{ .RelPermalink}}" {{if in .RelPermalink "0.20.13/"}} selected{{end}}>
     0.20.13
   </option>
-{{- end}}
+</select>

--- a/static/css/core-override.css
+++ b/static/css/core-override.css
@@ -1,4 +1,5 @@
-html, body {
+html,
+body {
   font-weight: 400;
 }
 
@@ -6,17 +7,20 @@ header {
   display: block;
 }
 
-article, .contentWidth {
+article,
+.contentWidth {
   max-width: 1250px;
-  width: 1250px;
 }
 
 .contentWidth {
   display: flex;
+  flex-wrap: wrap;
   margin: 0 auto;
+  width: 100%;
 }
 
 article {
+  width: 100vw;
   margin: 3.5rem auto 0;
 }
 article > aside {
@@ -32,7 +36,7 @@ img {
 }
 
 section a {
-  color: #2196C9;
+  color: #2196c9;
   font-weight: 500;
 }
 
@@ -44,18 +48,18 @@ section ul > li {
 }
 section ul > li:before {
   content: " ";
-  background: #2196C9;
+  background: #2196c9;
   width: 8px;
   height: 8px;
   border-radius: 8px;
-  margin-right: 1rem;    
+  margin-right: 1rem;
   margin-top: -3px;
   display: inline-block;
 }
 
 section ul ol,
 section ul ul {
-  padding: 0 2rem
+  padding: 0 2rem;
 }
 
 article section.page {
@@ -68,10 +72,51 @@ article section.page h3,
 article section.page h4,
 article section.page h5,
 article section.page strong {
-  color: #35393B;
+  color: #35393b;
 }
 
 section p {
   display: inline;
 }
 
+/** FLEEEEXXXX **/
+
+@media (max-width: 768px) {
+  header {
+    height: 7rem;
+  }
+  header .logo {
+    width: 100%;
+    flex: none;
+  }
+  header nav.shortcuts {
+    flex: none
+  }
+  header .searchbox {
+    padding-left: 0;
+    width: 40vw;
+  }
+
+  header nav.shortcuts li {
+    margin-right: 1rem;
+  }
+  header nav.shortcuts li a {
+    color: transparent;
+  }
+  header .fa-github {
+    color: white;
+  }
+
+  #version-selection-label {
+    display: none;
+  }
+
+  article > section.page {
+    margin: 0 0;
+    padding: 1rem;
+  }
+
+  article {
+    margin-top: 7rem;
+  }
+}

--- a/static/css/menu.css
+++ b/static/css/menu.css
@@ -1,6 +1,15 @@
+article .leftMenuBuffer {
+  background: #f9f9f9;
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  top: 3.5rem;
+  width: calc((100vw - 1250px) / 2);
+}
+
 article > aside {
-  padding-right: .5rem;
-  width: 21rem; 
+  padding-right: 0.5rem;
+  width: 21rem;
 }
 
 article > aside .menu {
@@ -16,23 +25,23 @@ article > aside .menu .topic-logo img {
 
 /* ITEMS */
 article > aside .menu .dd-item {
-  color: #ADB3BC;
-  padding-left: .5rem;
+  color: #adb3bc;
+  padding-left: 0.5rem;
   margin-left: -1px;
 }
 article > aside .menu .dd-item > div,
-article > aside .menu .dd-item ul li.dd-item > div  {
+article > aside .menu .dd-item ul li.dd-item > div {
   border-left: 5px solid transparent;
 }
-article > aside .menu .dd-item ul li.dd-item > div  {
+article > aside .menu .dd-item ul li.dd-item > div {
   padding-left: 0;
 }
 
 article > aside .menu .dd-item > div {
   margin-left: -1px;
-  padding-left: .75rem;
+  padding-left: 0.75rem;
 }
-article > aside .menu .dd-item > div, 
+article > aside .menu .dd-item > div,
 article > aside .menu .dd-item.haschildren > div {
   margin-left: -15px;
 }
@@ -51,34 +60,34 @@ article > aside .menu .dd-item > ul li {
 article > aside .menu .dd-item.haschildren ul li {
   padding-left: 0;
 }
-article > aside .menu .dd-item.haschildren ul li.dd-item > div  {
+article > aside .menu .dd-item.haschildren ul li.dd-item > div {
   padding-left: 0;
 }
 article > aside .menu .dd-item.haschildren ul li.dd-item > div a {
-  padding-left: .5rem;
+  padding-left: 0.5rem;
 }
 
 /* OPENED + ACTIVE */
 article > aside .menu .dd-item.active > div,
 article > aside .menu .dd-item ul li.dd-item.active > div {
-  border-left-color: #6AC7F0;
+  border-left-color: #6ac7f0;
 }
 
 article > aside .menu .dd-item.parent > ul {
-  border-left: 1px dashed #D4D8DE;
-  border-bottom: 1px dashed #D4D8DE;
+  border-left: 1px dashed #d4d8de;
+  border-bottom: 1px dashed #d4d8de;
   padding-left: 15px;
 }
 
 article > aside .menu .dd-item.parent div,
 article > aside .menu .dd-item.parent > div * {
-  color: #6E7477;
+  color: #6e7477;
 }
 article > aside .menu .dd-item.active > div {
   background: transparent;
 }
 article > aside .menu .dd-item.active > div * {
-  color: #35393B;
+  color: #35393b;
 }
 article > aside .menu .dd-item.parent.active > div * {
   color: #222;


### PR DESCRIPTION
The version menu should use the docsversion variable from the solo site variables.  However, the generation is tough to test currently and will require more changes, with some testing in the live environment, all of which needs to take a back-burner to more pressing issues.

A path is clearly laid out to change versionnavigation.html to an appropriate {{ range }} and test away.