### PR TITLE
Remove bad summary styling

### DIFF
--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -34,6 +34,9 @@ nav,
 section {
   display: block; }
 
+summary {
+  display: list-item; }
+
 audio,
 canvas,
 progress,

--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -31,8 +31,7 @@ header,
 hgroup,
 main,
 nav,
-section,
-summary {
+section {
   display: block; }
 
 audio,


### PR DESCRIPTION
Display styling has no effect right now except in Firefox, where it removes the toggle arrow.