### PR TITLE
Fix Index.json generation

### DIFF
--- a/layouts/index.json
+++ b/layouts/index.json
@@ -5,7 +5,7 @@
 	"uri": "{{ .Site.Data.Solo.DocsVersion }}{{ $page.RelPermalink }}",
 	"title": "{{ htmlEscape $page.Title}}",
 	"tags": [{{ range $tindex, $tag := $page.Params.tags }}{{ if $tindex }}, {{ end }}"{{ $tag| htmlEscape }}"{{ end }}],
-	"description": "{{ htmlEscape .Description}}",
+	"description": {{ htmlEscape .Description | jsonify}},
 	"content": {{$page.Plain | jsonify}}
 }
 {{- end -}}


### PR DESCRIPTION
# Context

Some page descriptions e.g. 
https://github.com/solo-io/gloo-mesh/blame/main/docs/content/reference/cli/_index.md#L4-L5
have new lines that aren't escaped in hugo theme index.json generation, causing the index.json to become invalid, as follows

![image](https://user-images.githubusercontent.com/1731122/109368735-15a50400-7868-11eb-9b9c-fb537b6a1dc9.png)

This change makes the markdown description json-friendly.
