### PR TITLE
Fix changelog rendering

### DIFF
--- a/layouts/shortcodes/render_changelog.html
+++ b/layouts/shortcodes/render_changelog.html
@@ -13,7 +13,7 @@
 
 
 <div id="solodocs-changelogdiv"></div>
-{{ $changelogPath := printf "%s/%s" "/static/content" (.Get "changelogJsonPath") | relUrl}}
+{{ $changelogPath := printf "%s/%s" "/static/content" (.Get "changelogJsonPath")|relURL}}
 <script>const changelogPath = '{{.Site.Data.Solo.DocsVersion}}{{$changelogPath}}'</script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js" integrity="sha512-L03kznCrNOfVxOUovR6ESfCz9Gfny7gihUX/huVbQB9zjODtYpxaVtIaAkpetoiyV2eqWbvxMH9fiSv5enX7bw==" crossorigin="anonymous"></script>
 <script src="{{ .Site.Data.Solo.DocsVersion }}{{"/changelog/Renderers.js"|relURL}}"></script>

--- a/layouts/shortcodes/render_changelog.html
+++ b/layouts/shortcodes/render_changelog.html
@@ -13,7 +13,8 @@
 
 
 <div id="solodocs-changelogdiv"></div>
-<script>const changelogPath = '{{.Site.Data.Solo.DocsVersion}}/static/content/{{ .Get "changelogJsonPath" }}'</script>
+{{ $changelogPath := printf "%s/%s" "/static/content" (.Get "changelogJsonPath") | relUrl}}
+<script>const changelogPath = '{{.Site.Data.Solo.DocsVersion}}{{$changelogPath}}'</script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js" integrity="sha512-L03kznCrNOfVxOUovR6ESfCz9Gfny7gihUX/huVbQB9zjODtYpxaVtIaAkpetoiyV2eqWbvxMH9fiSv5enX7bw==" crossorigin="anonymous"></script>
 <script src="{{ .Site.Data.Solo.DocsVersion }}{{"/changelog/Renderers.js"|relURL}}"></script>
 <script src="{{ .Site.Data.Solo.DocsVersion }}{{"/changelog/changelog_utils.js"|relURL}}"></script>


### PR DESCRIPTION
adds `relURL` filter to get the relative URL from the site base.