### PR TITLE
Remove comment that renders as HTML

### DIFF
--- a/layouts/shortcodes/render_changelog.html
+++ b/layouts/shortcodes/render_changelog.html
@@ -15,6 +15,7 @@
 <div id="solodocs-changelogdiv"></div>
 {{ $changelogPath := printf "%s/%s" "/static/content" (.Get "changelogJsonPath")|relURL}}
 <script>const changelogPath = '{{.Site.Data.Solo.DocsVersion}}{{$changelogPath}}'</script>
+<!-- Defer script execution till all scripts are fully parsed, so even if scripts are loaded out of order, no error is thrown at execution time -->
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js" integrity="sha512-L03kznCrNOfVxOUovR6ESfCz9Gfny7gihUX/huVbQB9zjODtYpxaVtIaAkpetoiyV2eqWbvxMH9fiSv5enX7bw==" crossorigin="anonymous"></script>
 <script defer src="{{ .Site.Data.Solo.DocsVersion }}{{"/changelog/Renderers.js"|relURL}}"></script>
 <script defer src="{{ .Site.Data.Solo.DocsVersion }}{{"/changelog/changelog_utils.js"|relURL}}"></script>

--- a/layouts/shortcodes/render_changelog.html
+++ b/layouts/shortcodes/render_changelog.html
@@ -15,7 +15,6 @@
 <div id="solodocs-changelogdiv"></div>
 {{ $changelogPath := printf "%s/%s" "/static/content" (.Get "changelogJsonPath")|relURL}}
 <script>const changelogPath = '{{.Site.Data.Solo.DocsVersion}}{{$changelogPath}}'</script>
-// Defer script execution till all scripts are fully parsed, so even if scripts are loaded out of order, no error is thrown at execution time
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js" integrity="sha512-L03kznCrNOfVxOUovR6ESfCz9Gfny7gihUX/huVbQB9zjODtYpxaVtIaAkpetoiyV2eqWbvxMH9fiSv5enX7bw==" crossorigin="anonymous"></script>
 <script defer src="{{ .Site.Data.Solo.DocsVersion }}{{"/changelog/Renderers.js"|relURL}}"></script>
 <script defer src="{{ .Site.Data.Solo.DocsVersion }}{{"/changelog/changelog_utils.js"|relURL}}"></script>

--- a/static/changelog/Renderers.js
+++ b/static/changelog/Renderers.js
@@ -237,7 +237,7 @@ class VersionComparer {
           }
         }
       }
-      output += Collapsible(`${header} (${count})`, noteStr);
+      output += Collapsible(`${header} (${count})`, noteStr, true);
     }
     return output;
   }

--- a/static/changelog/Renderers.js
+++ b/static/changelog/Renderers.js
@@ -305,10 +305,10 @@ class VersionComparer {
     });
 
     const [previousVersion, newVersion] = this.getVersionsFromHash();
-    if (previousVersion?.length > 0 && versions.includes(previousVersion)) {
+    if (previousVersion && previousVersion.length > 0 && versions.includes(previousVersion)) {
       this.oldVersionSelect.val(previousVersion);
     }
-    if (newVersion?.length > 0 && versions.includes(newVersion)) {
+    if (newVersion && newVersion.length > 0 && versions.includes(newVersion)) {
       this.newVersionSelect.val(newVersion);
     }
 

--- a/static/changelog/changelog_utils.js
+++ b/static/changelog/changelog_utils.js
@@ -81,6 +81,8 @@ function Link(title, link ) {
   return `[${title}](${link})`;
 }
 
+// Renderes a collapsible section, where content will only show if the title is expanded.
+// open determines whether or not the section is expanded by default
 function Collapsible(title, content, open=false) {
   return `\n<details ${open && 'open'}><summary >\n${title}</summary>\n${content}</details>\n `;
 }


### PR DESCRIPTION
the comment renders out in our changelog docs currently because it's not a HTML comment.
![image](https://user-images.githubusercontent.com/1731122/120651842-33789b00-c44d-11eb-806b-8559465f711e.png)
In addition, remove the elvis operator, as this is not compatible with chrome < v80.0.0