### PR TITLE
Add ability for doc sets to include a banner partial

### DIFF
--- a/changelog/v0.0.4/banner.yaml
+++ b/changelog/v0.0.4/banner.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/doctopus/issues/24
+    description: Add ability for doc sets to include a banner partial for a banner to show up on each page in the doc set.

--- a/layouts/partials/flex/body-beforecontent.html
+++ b/layouts/partials/flex/body-beforecontent.html
@@ -42,8 +42,7 @@
     </section>
   </aside>
   <section class="page">
-
-    
+  {{ partial "banner.html" . }} 
   <div class="nav-select">
     <center>Navigation : 
       <select onchange="javascript:location.href = this.value;">

--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -87,6 +87,7 @@ mark {
   text-align: center;
   border-radius: 10px;
   margin: 0.5rem;
+  margin-bottom: 2rem;
   padding: 0.25rem;
   border-style: solid;
   border-color: #35393B; }

--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -84,6 +84,7 @@ mark {
   background: #DDF4F9;
   color: #35393B;
   font-weight: bold;
+  font-size: x-large;
   text-align: center;
   border-radius: 10px;
   margin: 0.5rem;

--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -80,6 +80,17 @@ mark {
   border-style: solid;
   border-color: #35393B; }
 
+.banner {
+  background: #DDF4F9;
+  color: #35393B;
+  font-weight: bold;
+  text-align: center;
+  border-radius: 10px;
+  margin: 0.5rem;
+  padding: 0.25rem;
+  border-style: solid;
+  border-color: #35393B; }
+
 sub,
 sup {
   font-size: 0.8rem;

--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -71,8 +71,14 @@ dfn {
   font-style: italic; }
 
 mark {
-  background: #FFFF27;
-  color: #333; }
+  background: #FCCCB3;
+  color: #35393B;
+  border-radius: 10px;
+  margin: 0.25rem;
+  padding: 0.5rem;
+  padding-bottom: 0.25rem;
+  border-style: solid;
+  border-color: #35393B; }
 
 sub,
 sup {


### PR DESCRIPTION
For issue: https://github.com/solo-io/doctopus/issues/24

The empty `banner.html` file is so that doc sets that do not include a `docs/layouts/partial/banner.html` file won't get a crashed page.
BOT NOTES: 
resolves https://github.com/solo-io/doctopus/issues/24