### PR TITLE
Moving where banner class is in the CSS file

### DIFF
--- a/static/css/nucleus.css
+++ b/static/css/nucleus.css
@@ -80,19 +80,6 @@ mark {
   border-style: solid;
   border-color: #35393B; }
 
-.banner {
-  background: #DDF4F9;
-  color: #35393B;
-  font-weight: bold;
-  font-size: x-large;
-  text-align: center;
-  border-radius: 10px;
-  margin: 0.5rem;
-  margin-bottom: 2rem;
-  padding: 0.25rem;
-  border-style: solid;
-  border-color: #35393B; }
-
 sub,
 sup {
   font-size: 0.8rem;
@@ -550,6 +537,19 @@ h6 {
 
 p {
   margin: 1.7rem 0; }
+
+.banner {
+  background: #DDF4F9;
+  color: #35393B;
+  font-weight: bold;
+  font-size: x-large;
+  text-align: center;
+  border-radius: 10px;
+  margin: 0.5rem;
+  margin-bottom: 2rem;
+  padding: 0.25rem;
+  border-style: solid;
+  border-color: #35393B; }
 
 ul, ol {
   margin-top: 1.7rem;


### PR DESCRIPTION
I noticed in the Gloo Mesh docs that the `main` and `latest` branches did not style the banner partial, but the outdated `1.0` [branch](https://docs.solo.io/gloo-mesh-open-source/1.0.13/getting_started/) did.

I believe this is because the `.banner` CSS class was after the `mark` element, so this moves it to be after the `p` element. Still seemed to work locally. The local env seems to always show an outdated version so I think that's why it looked right during local tests for the previous PR #39 

1.0
![image](https://user-images.githubusercontent.com/20074219/134378681-4bef968b-6a73-49d4-917f-ab53aa813faf.png)

Main or latest
![image](https://user-images.githubusercontent.com/20074219/134378730-5d497ed8-51b4-41f5-93df-ee6d2ad2c170.png)


