### PR TITLE
bold tab links

### DIFF
--- a/static/css/tabs.css
+++ b/static/css/tabs.css
@@ -16,6 +16,7 @@
 }
 
 .ui-widget.ui-widget-content a{
+  font-weight: bold;
   color: #2196c9;
 }
 

--- a/static/css/tabs.css
+++ b/static/css/tabs.css
@@ -35,6 +35,7 @@
   display: none;
 }
 .ui-widget.ui-widget-content.ui-tabs .ui-tabs-nav li a {
+  font-weight: normal;
   background: #F2F2F2;
   color: #707070;
 }


### PR DESCRIPTION
Ensure hyperlinks within tabs are bolded without impacting tab headers

Before:
<img width="1242" alt="Screen Shot 2021-11-08 at 3 41 57 PM" src="https://user-images.githubusercontent.com/2321247/140815183-53138db5-8bf4-4f13-846b-f2baaeabfa55.png">

After:
<img width="1239" alt="Screen Shot 2021-11-08 at 3 41 33 PM" src="https://user-images.githubusercontent.com/2321247/140815201-b537c4cf-873f-4701-97f4-835bac06651e.png">

This is necessary because the font family within tabs doesn't render differently with weight `500` (default for hyperlinks) compared to `400` (for normal text). Use of `bold` ensures the font will stand out. This is especially important in cases where the font color is the same as the surrounding text as in a note block:

<img width="1210" alt="Screen Shot 2021-11-08 at 3 45 41 PM" src="https://user-images.githubusercontent.com/2321247/140815521-9f4e6d74-3307-4cd9-9db5-f3866afcd568.png">


