### PR TITLE
increase image size when zoomed (featherlight JS)

### DIFF
--- a/changelog/v0.0.10/img-size-zoomed.yaml
+++ b/changelog/v0.0.10/img-size-zoomed.yaml
@@ -1,3 +1,4 @@
 changelog:
   - type: FIX
+    issuelink: https://github.com/solo-io/hugo-theme-soloio/issues/46
     description: Increases max height for featherlight images.

--- a/changelog/v0.0.10/tabs.yaml
+++ b/changelog/v0.0.10/tabs.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: FIX
+    description: Increases max height for featherlight images.

--- a/static/css/core-override.css
+++ b/static/css/core-override.css
@@ -38,6 +38,10 @@ img {
   max-height: 500px;
 }
 
+div.featherlight img {
+  max-height: 900px;
+}
+
 section a {
   color: #2196c9;
   font-weight: 500;


### PR DESCRIPTION
Previously, the image displayed in the lightbox was limited to 500px height
I increased this value to 900px, which makes the zoomed image bigger.

Example:

![image](https://user-images.githubusercontent.com/9626829/147212187-061252e3-bc27-45e2-a23f-67c64e2c503f.png)

BOT NOTES: 
resolves https://github.com/solo-io/hugo-theme-soloio/issues/46