### PR TITLE
Scroll overlap fix

### DIFF
--- a/changelog/v0.0.14/scroll-overlap-fix.yaml
+++ b/changelog/v0.0.14/scroll-overlap-fix.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fixes page overlapping side nav when horizontally scrolling.

--- a/static/css/menu.css
+++ b/static/css/menu.css
@@ -9,6 +9,7 @@ article > aside {
   background-color: #F8FAFB;
   box-shadow: 0px 2px 8px #253E580B;
   padding-top: 0;
+  z-index: 1;
 }
 
 article > aside .menu {


### PR DESCRIPTION
Fixes a bug where the article content can overlap the side nav
![Screen Shot 2022-03-04 at 4 24 17 PM](https://user-images.githubusercontent.com/7085474/156844468-1cfb4d73-69b3-4893-852b-c253c28f7ad0.png)

