### PR TITLE
add a flag in the readfile shortcode 

### DIFF
--- a/changelog/v0.0.17/skip-security-scan-rendering.yaml
+++ b/changelog/v0.0.17/skip-security-scan-rendering.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add a flag to skip security scan rendering

--- a/layouts/shortcodes/readfile.html
+++ b/layouts/shortcodes/readfile.html
@@ -1,6 +1,16 @@
 {{$file := .Get "file"}}
-{{- if eq (.Get "markdown") "true" -}}
-{{- $file  | readFile | markdownify -}}
+
+{{- if and (eq (.Get "type") "SECURITY_SCAN") .Site.Params.noSecurityScan -}}
+skip reading security scan for file <em>{{ $file }}</em>
+<br/>
+
 {{- else -}}
-{{ $file  | readFile | safeHTML }}
+
+    {{$file := .Get "file"}}
+    {{- if eq (.Get "markdown") "true" -}}
+    {{- $file  | readFile | markdownify -}}
+    {{- else -}}
+    {{ $file  | readFile | safeHTML }}
+    {{- end -}}
+
 {{- end -}}


### PR DESCRIPTION
add a flag in the `readfile` shortcode to skip the logic if the user asked for it and in case of a security scan report file