### PR TITLE
Adding script for TechTarget tracking

### DIFF
--- a/changelog/v0.0.17/fix-ul-and-code-copy.yaml
+++ b/changelog/v0.0.17/fix-ul-and-code-copy.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Adds an inbound converter script to enable TechTarget processing of docs traffic.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,3 +27,19 @@
 <a id="logo" href="https://www.solo.io/docs">
   <img src="{{ .Site.Data.Solo.DocsVersion }}/images/Solo-Docs-Logo.svg" />
 </a>
+
+<!--Tech Target script from marketing for EMEA research-->
+<script> (function(w, d, c) {
+    w['techtargetic'] = w['techtargetic'] || {};
+    w['techtargetic'].client = c;
+    var s = d.createElement("script");
+    s.type = "text/javascript";
+    s.async = !0;
+    s.crossorigin = "anonymous";
+    var rd = new Date();
+    rd = rd.getFullYear() + '' + rd.getMonth() + rd.getDate();
+    s.src = "https://trk.techtarget.com/tracking.js";
+    var n = d.getElementsByTagName("script")[0];
+    n.parentNode.insertBefore(s, n);})
+    (window, document, '20411403');
+</script>


### PR DESCRIPTION
* Followed a similar approach as enabling Google Analytics for the webpages (PR #47 )
* Request from Marketing/Samantha

### Background

We have a tool set up for the EMEA sales reps to view intelligence about companies and individuals within EMEA that are researching on key areas like service mesh and API gateway both on the TechTarget network and on [Solo.io](http://solo.io/) properties. We have this tracking code on [solo.io](http://solo.io/), [solocon.io](http://solocon.io/), [bumblebee.io](http://bumblebee.io/), and [academy.solo.io](http://academy.solo.io/) and it would be great to also implement on our Docs site!

Here are some implementation requirements and recommendations from Tech Target:
* For jurisdictions requiring a lawful basis prior to the processing of IP traffic on your website, including the subsequent transfer to TechTarget for further processing, it is recommended that you list TechTarget with your Consent Management Provider, Tag Manager, or other similar solution.
* We recommend implementing our script using a tag management tool for ease of set-up and control, for example Google Tag Manager.

With the above said, your unique Inbound Converter script is in the attached TXT file.
[Solo.io_Inbound Converter JS Snippet (1).txt](https://github.com/solo-io/hugo-theme-soloio/files/8318719/Solo.io_Inbound.Converter.JS.Snippet.1.txt)
 