### PR TITLE
Revise URL

### DIFF
--- a/changelog/v0.0.20/docs-landing-page.yaml
+++ b/changelog/v0.0.20/docs-landing-page.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix the landing page link docs.solo.io

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
   defer
   src="//js.hs-scripts.com/5130874.js"
 ></script>
-<a id="logo" href="docs.solo.io">
+<a id="logo" href="https://docs.solo.io/">
   <img src="{{ .Site.Data.Solo.DocsVersion }}/images/Solo-Docs-Logo.svg" />
 </a>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,7 +24,7 @@
   defer
   src="//js.hs-scripts.com/5130874.js"
 ></script>
-<a id="logo" href="https://www.docs.solo.io/">
+<a id="logo" href="docs.solo.io">
   <img src="{{ .Site.Data.Solo.DocsVersion }}/images/Solo-Docs-Logo.svg" />
 </a>
 


### PR DESCRIPTION
Based on feedback in [slack](https://solo-io-corp.slack.com/archives/GR4NQ5TQA/p1656086149912969):  the solo.io Docs icon on the docs site actually links to https://www.docs.solo.io/ rather than https://docs.solo.io/. www.docs.solo.io doesn’t resolve to anything. Confused me when I clicked on it for a sec because chrome hides the www in the address so I’m sure it could hold someone else up too.

Followup to https://github.com/solo-io/hugo-theme-soloio/pull/57