### PR TITLE
fix the version links in the changelog pages

### DIFF
--- a/changelog/v0.0.29/changelog-link.yaml
+++ b/changelog/v0.0.29/changelog-link.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    resolvesIssue: false
+    issueLink: https://github.com/solo-io/doctopus/issues/42
+    description: Fixes the way changelog links are rendered. 

--- a/static/changelog/Renderers.js
+++ b/static/changelog/Renderers.js
@@ -61,7 +61,7 @@ class MarkdownRenderer {
   }
 
   renderMarkdown(showOSNotes) {
-    let extensions = ['auto-url'];
+    let extensions = [];
     if (!this.discludeHeaderAnchors) {
       extensions.push('header-anchors');
     }
@@ -201,7 +201,7 @@ class VersionComparer {
     const renderer = new showdown.Converter({
       headerLevelStart: 3,
       prefixHeaderId: this.headerIdPrefix+HASH_SEPARATOR,
-      extensions: ['auto-url']
+      extensions: []
     });
     return renderer.makeHtml(markdown);
   }


### PR DESCRIPTION
See https://github.com/solo-io/docs/pull/295 and https://solo-io-corp.slack.com/archives/CHJV572TG/p1713835577300559